### PR TITLE
Revert the "set -e" in test script to capture the non-zero exit code …

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -101,6 +101,7 @@ rec {
   } ''
     mkdir $out
     (
+    set +e # Dont exit on error, do the cleanup/kill of background processes
     ${toString speculosCmd} ${appExe} --display headless &
     SPECULOS=$!
 


### PR DESCRIPTION
…and cleanup properly

Fixes the hang when mocha-wrapper returns non-zero exit code.