### PR TITLE
Some improvements to the deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ By using Nix, this can be done simply by using the `load-app` command, without m
 
 ```bash
 tar xzf /path/to/release.tar.gz
-cd alamgu-example
+cd alamgu-example-$DEVICE
 nix-shell
 load-app
 ```
@@ -107,7 +107,7 @@ For more information on how to install and use that tool see the [instructions f
 
 ```bash
 tar xzf release.tar.gz
-cd alamgu-example
+cd alamgu-example-$DEVICE
 ledgerctl install -f app.json
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -80,8 +80,11 @@ rec {
 
     cargo-ledger --use-prebuilt ${appExe} --hex-next-to-json ledger ${device}
 
-    dest=$out/${appName}
-    mkdir -p $dest
+    dest=$out/${appName}-${device}
+    mkdir -p $dest/dep
+
+    # Copy Alamgu build infra thunk
+    cp -r ${./dep/alamgu} $dest/dep/alamgu
 
     # Create a file to indicate what device this is for
     echo ${device} > $dest/device
@@ -177,7 +180,7 @@ rec {
 
     tarSrc = makeTarSrc { inherit appExe device; };
     tarball = pkgs.runCommandNoCC "${appName}-${device}.tar.gz" { } ''
-      tar -czvhf $out -C ${tarSrc} ${appName}
+      tar -czvhf $out -C ${tarSrc} "${appName}-${device}"
     '';
 
     loadApp = pkgs.writeScriptBin "load-app" ''
@@ -186,7 +189,7 @@ rec {
       ${alamgu.ledgerctl}/bin/ledgerctl install -f ${tarSrc}/${appName}/app.json
     '';
 
-    tarballShell = import (tarSrc + "/${appName}/shell.nix");
+    tarballShell = import (tarSrc + "/${appName}-${device}/shell.nix");
 
     speculosDeviceFlags = {
       nanos = [ "-m" "nanos" ];

--- a/tarball-default.nix
+++ b/tarball-default.nix
@@ -1,5 +1,5 @@
 rec {
-  alamgu = import (fetchTarball "https://github.com/alamgu/alamgu/archive/develop.tar.gz") {};
+  alamgu = import (import ./dep/alamgu/thunk.nix) {};
   ledgerctl = alamgu.ledgerctl;
   this = ./.;
   load-app = alamgu.pkgs.writeScriptBin "load-app" ''


### PR DESCRIPTION
- Alamgu build infra is pinned in the tarball shell, no more impurity with that.

- Tarball directory contains the app & device name now, not just the former.